### PR TITLE
added repitions of simulations indexed via random seeds

### DIFF
--- a/n_t/Snakefile
+++ b/n_t/Snakefile
@@ -3,12 +3,21 @@ import pathlib
 import stairway
 import simulations
 import plots
+import numpy as np
+import sys
 
 stairwayplot_code = "stairwayplot/swarmops.jar"
 
+seed = 12345
+np.random.seed(seed)
+
+reps = 2
+seed_array = np.random.random_integers(1,2**32,reps)
+chrm_list = ["chr22"]
 rule all:
    input:
-       "homo_sapiens_Gutenkunst/estimated_Ne.png"
+       expand("homo_sapiens_Gutenkunst/{seeds}.{chrms}.estimated_Ne.png",
+		seeds=seed_array, chrms=chrm_list)
 
 rule sp_download:
     output:
@@ -18,25 +27,24 @@ rule sp_download:
     shell:
         "wget http://sesame.uoregon.edu/~adkern/stdpopsim/stairwayplot.tar.gz && \
         tar zxf stairwayplot.tar.gz"
-   
 
 rule homo_sapiens_Gutenkunst_simulation:
     output:
-        "homo_sapiens_Gutenkunst/simulated.trees"
+        "homo_sapiens_Gutenkunst/{seeds}.{chrms}.trees"
     # TODO get simulation parameters from stdpopsim, so we can share them easily 
     # with anlysis code below?
-    run: simulations.homo_sapiens_Gutenkunst(output[0])
+    run: simulations.homo_sapiens_Gutenkunst(output[0], wildcards.seeds, wildcards.chrms)
 
 rule homo_sapiens_Gutenkunst_stairwayplot:
     input:
-        "homo_sapiens_Gutenkunst/simulated.trees",
+        "homo_sapiens_Gutenkunst/{seeds}.{chrms}.trees",
         stairwayplot_code,
     output:
-        "homo_sapiens_Gutenkunst/estimated_Ne.txt"
+        "homo_sapiens_Gutenkunst/{seeds}.{chrms}.estimated_Ne.txt"
     threads: 8
     run: 
         runner = stairway.StairwayPlotRunner(
-            workdir="homo_sapiens_Gutenkunst/stairwayplot",
+            workdir="homo_sapiens_Gutenkunst/stairwayplot/"+wildcards.seeds+"/",
             stairway_dir=pathlib.Path.cwd() / "stairwayplot")
         runner.ts_to_stairway(input[0], num_bootstraps=10)
         runner.run_theta_estimation(max_workers=threads, show_progress=True)
@@ -45,9 +53,9 @@ rule homo_sapiens_Gutenkunst_stairwayplot:
 
 rule homo_sapiens_Gutenkunst_stairwayplot_plot:
     input:
-        "homo_sapiens_Gutenkunst/estimated_Ne.txt"
+        "homo_sapiens_Gutenkunst/{seeds}.{chrms}.estimated_Ne.txt"
     output:
-        "homo_sapiens_Gutenkunst/estimated_Ne.png"
+        "homo_sapiens_Gutenkunst/{seeds}.{chrms}.estimated_Ne.png"
     run: plots.plot_stairway_Ne_estimate(input[0], output[0])
 
 

--- a/n_t/Snakefile
+++ b/n_t/Snakefile
@@ -12,7 +12,7 @@ seed = 12345
 np.random.seed(seed)
 
 reps = 2
-seed_array = np.random.random_integers(1,2**32,reps)
+seed_array = np.random.random_integers(1,2**31,reps)
 chrm_list = ["chr22"]
 rule all:
    input:

--- a/n_t/simulations.py
+++ b/n_t/simulations.py
@@ -4,10 +4,10 @@ Module to run the required simulations.
 
 import msprime
 from stdpopsim import homo_sapiens
+import sys
 
-
-def homo_sapiens_Gutenkunst(path, sample_size=20):
-    chrom = homo_sapiens.genome.chromosomes["chr22"]
+def homo_sapiens_Gutenkunst(path, seed, chrmStr, sample_size=20):
+    chrom = homo_sapiens.genome.chromosomes[chrmStr]
     recomb_map = chrom.recombination_map()
 
     model = homo_sapiens.GutenkunstThreePopOutOfAfrica()
@@ -19,5 +19,6 @@ def homo_sapiens_Gutenkunst(path, sample_size=20):
         samples=samples,
         recombination_map=chrom.recombination_map(),
         mutation_rate=chrom.mean_mutation_rate,
+        random_seed=seed,
         **model.asdict())
     ts.dump(path)


### PR DESCRIPTION
Using the `Snakefile` I created simple expansions for repetitions that get indexed by a set of random seeds. I've also added an expansion over a possible range of chromosomes. `snakemake -j n` where n > 1 will allow the workflow to do the simulation reps on multiple cores simultaneously. 