### PR TITLE
added smc++ analysis section, associated utils, and snakemake rules

### DIFF
--- a/n_t/Snakefile
+++ b/n_t/Snakefile
@@ -1,24 +1,30 @@
 import pathlib
 
 import stairway
+import smc
 import simulations
 import plots
 import numpy as np
 import sys
+import os
 
 stairwayplot_code = "stairwayplot/swarmops.jar"
 
 seed = 12345
 np.random.seed(seed)
 
-reps = 2
+reps = 2 
 seed_array = np.random.random_integers(1,2**31,reps)
 chrm_list = ["chr22"]
 rule all:
    input:
        expand("homo_sapiens_Gutenkunst/{seeds}.{chrms}.estimated_Ne.png",
 		seeds=seed_array, chrms=chrm_list),
-       "homo_sapiens_Gutenkunst/estimated_Ne.png"
+       "homo_sapiens_Gutenkunst/estimated_Ne.png",
+        expand("homo_sapiens_Gutenkunst/{seeds}.{chrms}.trees.smc.gz.final.json.csv",
+		seeds=seed_array, chrms=chrm_list),
+	"homo_sapiens_Gutenkunst/smcpp_estimated_Ne.png",
+        "homo_sapiens_Gutenkunst/all_estimated_Ne.png"
 
 rule sp_download:
     output:
@@ -60,8 +66,8 @@ rule homo_sapiens_Gutenkunst_stairwayplot_plot:
     run: plots.plot_stairway_Ne_estimate(input[0], output[0])
 
 def ne_files(wildcards):
-    return(expand("homo_sapiens_Gutenkunst/{seeds}.{chrms}.estimated_Ne.txt",
-            seeds=seed_array, chrms=chrm_list))
+    return expand("homo_sapiens_Gutenkunst/{seeds}.{chrms}.estimated_Ne.txt", \
+            seeds=seed_array, chrms=chrm_list)
 
 rule homo_sapiens_compound_stairwayplot:
     input:
@@ -69,6 +75,47 @@ rule homo_sapiens_compound_stairwayplot:
     output:
         "homo_sapiens_Gutenkunst/estimated_Ne.png"
     run: plots.plot_compound_Ne_estimate(input, output[0])
+
+
+rule homo_sapiens_smcpp:
+    input:
+        "homo_sapiens_Gutenkunst/{seeds}.{chrms}.trees"
+    output:
+        "homo_sapiens_Gutenkunst/{seeds}.{chrms}.trees.smc.gz.final.json"
+    threads: 8
+    run:
+        os.chdir("homo_sapiens_Gutenkunst")
+        fn = os.path.basename(input[0])
+        smc.write_smcpp_file(fn)
+        # TODO get the rate here from stdpopsim
+        smc.run_smcpp_estimate(fn + ".smc.gz", mutation_rate=1e-8, ncores=threads)
+        os.chdir("../")
+
+rule homo_sapiens_smcpp_plot:
+    input: rules.homo_sapiens_smcpp.output
+    output: "homo_sapiens_Gutenkunst/{seeds}.{chrms}.trees.smc.gz.final.json.csv"
+    run:
+        # TODO get the genetion time from std source
+        smc.run_smcpp_plot(input[0], generation_time=10)
+
+def ne_files_smcpp(wildcards):
+    return expand("homo_sapiens_Gutenkunst/{seeds}.{chrms}.trees.smc.gz.final.json.csv", \
+            seeds=seed_array, chrms=chrm_list)
+
+rule homo_sapiens_compound_smcpp:
+    input:
+        ne_files_smcpp
+    output:
+        "homo_sapiens_Gutenkunst/smcpp_estimated_Ne.png"
+    run: plots.plot_compound_smcpp(input, output[0])
+
+rule homo_sapiens_all_plot:
+    input:
+        f1 = ne_files,
+        f2 = ne_files_smcpp,
+    output:
+        "homo_sapiens_Gutenkunst/all_estimated_Ne.png"
+    run: plots.plot_all_ne_estimates(input.f1, input.f2, output[0])
 
 rule clean:
     shell:

--- a/n_t/plots.py
+++ b/n_t/plots.py
@@ -2,12 +2,15 @@
 Code for generating plots.
 """
 
-import numpy as np
+import pandas
+import seaborn as sns
 import matplotlib
+from matplotlib import pyplot as plt
 # Force matplotlib to not use any Xwindows backend.
 matplotlib.use('Agg')
-from matplotlib import pyplot as plt
-import pandas
+
+sns.set_style("darkgrid")
+
 
 def plot_stairway_Ne_estimate(infile, outfile):
 
@@ -15,13 +18,11 @@ def plot_stairway_Ne_estimate(infile, outfile):
     nt = nt[nt['year'] > 10]
     f, ax = plt.subplots(figsize=(7, 7))
     ax.set(xscale="log", yscale="log")
-    # JK: turned off these limits as they weren't working for me.
-           # ylim=(np.min(nt['Ne_2.5%']-np.std(nt['Ne_2.5%'])),
-           #       np.max(nt['Ne_97.5%'])+np.std(nt['Ne_97.5%'])))
     ax.plot(nt['year'], nt['Ne_median'], c="red")
     ax.plot(nt['year'], nt['Ne_2.5%'], c='grey')
     ax.plot(nt['year'], nt['Ne_97.5%'], c='grey')
     f.savefig(outfile, bbox_inches='tight')
+
 
 def plot_compound_Ne_estimate(infiles, outfile):
 
@@ -30,11 +31,34 @@ def plot_compound_Ne_estimate(infiles, outfile):
     for infile in infiles:
         nt = pandas.read_csv(infile, sep="\t", skiprows=5)
         nt = nt[nt['year'] > 10]
-        # JK: turned off these limits as they weren't working for me.
-               # ylim=(np.min(nt['Ne_2.5%']-np.std(nt['Ne_2.5%'])),
-               #       np.max(nt['Ne_97.5%'])+np.std(nt['Ne_97.5%'])))
         ax.plot(nt['year'], nt['Ne_median'], c="red")
-#        ax.plot(nt['year'], nt['Ne_2.5%'], c='grey')
-#        ax.plot(nt['year'], nt['Ne_97.5%'], c='grey')
 
     f.savefig(outfile, bbox_inches='tight')
+
+
+def plot_compound_smcpp(infiles, outfile):
+    f, ax = plt.subplots(figsize=(7, 7))
+    ax.set(xscale="log", yscale="log")
+    for infile in infiles:
+        nt = pandas.read_csv(infile, usecols=[1, 2], skiprows=0)
+        ax.plot(nt['x'], nt['y'], c="red")
+    f.savefig(outfile, bbox_inches='tight')
+
+
+def plot_all_ne_estimates(sp_infiles, smcpp_infiles, outfile):
+    f, ax = plt.subplots(figsize=(7, 7))
+    ax.set(xscale="log", yscale="log")
+    # plot smcpp estimates
+    for infile in smcpp_infiles:
+        nt = pandas.read_csv(infile, usecols=[1, 2], skiprows=0)
+        line1, = ax.plot(nt['x'], nt['y'], c="red", alpha=0.8, label='smc++')
+    # plot stairwayplot estimates
+    for infile in sp_infiles:
+        nt = pandas.read_csv(infile, sep="\t", skiprows=5)
+        line2, = ax.plot(nt['year'], nt['Ne_median'], c="blue", label='stairwayplot')
+    # TODO add a plot  of true history
+
+    ax.set_xlabel("time (years)")
+    ax.set_ylabel("population size")
+    ax.legend((line1, line2), ('smc++', 'stairwayplot'))
+    f.savefig(outfile, bbox_inches='tight', alpha=0.8)

--- a/n_t/readme.md
+++ b/n_t/readme.md
@@ -1,4 +1,4 @@
-#Readme for N(t) example
+# Readme for N(t) example
 This directory has a quick example of a workflow for estimating changing 
 population size over time from a simulated sample ($N(t)$) using
 stairwayplot. The basic workflow is organized using `snakemake`
@@ -17,7 +17,16 @@ everything out using
 
 `$ snakemake clean`
 
-###Cluster environments
+### Dependencies
+Most dependencies can be loaded in using `pip install -r requirements.txt`. An exception
+to this is `smp++` which uses `conda` for its install. The simplest install should be 
+achieved using
+
+ `$ conda install -c terhorst -c bioconda smcpp`
+
+Further details on `smc++` and its use can be found [here](https://github.com/popgenmethods/smcpp)
+
+### Cluster environments
 Our workflow can also be run on a cluster. To do so requires
 the setup of a `.json` configuration file that lets `snakemake`
 know about your cluster. We have provided an example of 
@@ -29,3 +38,6 @@ The workflow can then be launched with the call
 `$ snakemake -j 999 --cluster-config cluster_talapas.json --cluster "sbatch -p {cluster.partition} -n {cluster.n}  -t {cluster.time}"`
 
 and jobs will be automatically farmed out to the cluster
+
+### Final output
+The current final output is a plot comparing stairwayplot and smc++ estimates of $N(t)$, i.e., `homo_sapiens_Gutenkunst/all_estimated_Ne.png`  

--- a/n_t/simulations.py
+++ b/n_t/simulations.py
@@ -4,11 +4,10 @@ Module to run the required simulations.
 
 import msprime
 from stdpopsim import homo_sapiens
-import sys
+
 
 def homo_sapiens_Gutenkunst(path, seed, chrmStr, sample_size=20):
     chrom = homo_sapiens.genome.chromosomes[chrmStr]
-    recomb_map = chrom.recombination_map()
 
     model = homo_sapiens.GutenkunstThreePopOutOfAfrica()
     # model.debug()

--- a/n_t/smc.py
+++ b/n_t/smc.py
@@ -1,0 +1,56 @@
+"""
+Utilities for working with scm++
+"""
+import logging
+import subprocess
+import tskit
+
+
+def write_smcpp_file(path):
+    """
+    Writes a smcpp input file given a treesequence
+    """
+    ts = tskit.load(path)
+    # write a vcf intermediate input
+    with open(path+".vcf", "w") as vcf_file:
+        ts.write_vcf(vcf_file, 2)
+    # index the vcf
+    cmd = ("bgzip " + path + ".vcf")
+    logging.info("Running:" + cmd)
+    subprocess.run(cmd, shell=True, check=True)
+    vz_file = path + ".vcf.gz"
+    cmd = ("tabix " + vz_file)
+    logging.info("Running:" + cmd)
+    subprocess.run(cmd, shell=True, check=True)
+    # run smc++ for vcf conversion
+    smc_file = path + ".smc.gz"
+    cmd = "smc++ vcf2smc " + vz_file + " " + \
+        smc_file + " 1 pop1:"
+    for n in range(ts.num_samples // 2):
+        cmd = cmd + "msp_" + str(n) + ","
+    cmd = cmd[0:-1]
+    logging.info("Running:" + cmd)
+    subprocess.run(cmd, shell=True, check=True)
+
+
+def run_smcpp_estimate(input_file, mutation_rate, ncores):
+    """
+    Runs smc++ estimate on the specified file, resulting in the output being written
+    to the file input_file.final.jason".
+    """
+    cmd = (
+        f"smc++ estimate "
+        f"{mutation_rate} {input_file} --base {input_file} --cores {ncores}")
+    logging.info("Running:" + cmd)
+    subprocess.run(cmd, shell=True, check=True)
+
+
+def run_smcpp_plot(input_file, generation_time):
+    """
+    Runs smc++ plot on the specified file, resulting in the output being written
+    to the file input_file.png".
+    """
+    cmd = (
+        f"smc++ plot {input_file}.png {input_file} -g {generation_time} -c")
+    logging.info("Running:" + cmd)
+    subprocess.run(cmd, shell=True, check=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ setuptools
 matplotlib
 pandas
 tqdm
+seaborn


### PR DESCRIPTION
spent the day extending the pipeline to include smc++ for estimation of N(t) on the homo_sapiens model. smc++ installation isn't *that* simple and involves either a bunch of library dependencies to build from source or a call to `conda install`. I've documented this in the N(t) [readme](https://github.com/andrewkern/analysis/tree/smcpp/n_t).

currently I have as the final output from the workflow a figure that is generated in `homo_sapiens_Gutenkunst/` that compares the estimates between the two software packages across all replicates (i.e. seeds, chroms). Ideally I would like to include the true population size history as another curve, but it would be best if there was a programmatic way to pull that from a `msprime` model. I've raised an issue on `tskit-dev` [here](https://github.com/tskit-dev/msprime/issues/724) asking if such a feature exists. 