### PR TITLE
Workaround for genetic map cache issue.

### DIFF
--- a/n_t/Snakefile
+++ b/n_t/Snakefile
@@ -1,12 +1,16 @@
 import pathlib
+import sys
+
+import numpy as np
+import stdpopsim
 
 import stairway
 import simulations
 import plots
-import numpy as np
-import sys
+
 
 stairwayplot_code = "stairwayplot/swarmops.jar"
+genetic_map_downloaded_flag= ".genetic_map_downloaded"
 
 seed = 12345
 np.random.seed(seed)
@@ -29,7 +33,21 @@ rule sp_download:
         "wget http://sesame.uoregon.edu/~adkern/stdpopsim/stairwayplot.tar.gz && \
         tar zxf stairwayplot.tar.gz"
 
+
+rule download_genetic_map:
+    output: genetic_map_downloaded_flag
+    message: "Downloading default genetic map"
+    run:
+        # We need to have this here to avoid several threads trying to download the 
+        # the genetic map into the cache at the same time.
+        genetic_map = stdpopsim.homo_sapiens.HapmapII_GRCh37()
+        if not genetic_map.is_cached():
+            genetic_map.download()
+        with open(output[0], "w") as f:
+            print("File to indicate genetic map has been downloaded", file=f)
+
 rule homo_sapiens_Gutenkunst_simulation:
+    input: genetic_map_downloaded_flag
     output:
         "homo_sapiens_Gutenkunst/{seeds}.{chrms}.trees"
     # TODO get simulation parameters from stdpopsim, so we can share them easily 


### PR DESCRIPTION
This is a quick workaround that'll fix some of the problems @agladstein  is having. I'll fix the actual race condition in https://github.com/popgensims/stdpopsim/issues/38, so that we at least get correct results for all threads. However, we probably don't want to kick of n-different threads downloading the same genetic map at the same time, so we probably need something like this whatever we do.

Unless we manually specify the cache directory, I'm not sure we can do much else here.

I've hardcoded in HapmapII_GRCh37 here, but I guess we should set up some sort of linkage to the simulation module so that we know we're downloading the right map.