### PR TITLE
Refactored analysis workflow.

### DIFF
--- a/n_t/Snakefile
+++ b/n_t/Snakefile
@@ -31,45 +31,60 @@ import plots
 
 
 # A seed to replicate results
-# TODO This heuristic may need a changed?
-# TODO Generation time
 # TODO mutation rates
-# TODO 
 
-seed = 12345
-np.random.seed(seed)
+configfile: config["config"]+"/config.json"
+
+np.random.seed(config["seed"])
+
+# TODO This should end up being a list 
+# so that we may sample from multiple populations.
+# doing this may be a little tricky for msmc sub-sampling?
+population_id = config["population_id"]
 
 # This is the number of samples to simulate for each analysis
-num_sampled_genomes_per_replicate = 20
+num_sampled_genomes_per_replicate = config["num_sampled_genomes_per_replicate"]
 
 # Here is a list of sample sizes to run msmc on. 
 # Each element counts as its own analysis
 # so there will be "replicates" runs for each size
-num_sampled_genomes_msmc = [8,4]
+num_sampled_genomes_msmc = [int(x) for x in config["num_sampled_genomes_msmc"].split()]
 
 # The number of msmc Baumwelch(?) iterations to run,
 # typically 20
-num_msmc_iterations = 20
+num_msmc_iterations = config["num_msmc_iterations"]
 
 # The number of replicates of each analysis you would like to run
-replicates = 2
+replicates = config["replicates"]
 
 # Where you would like all output files from analysis to live
-output_dir = "drosophila_melanogaster"
+output_dir = config["config"]
 
 # The analysis species
-species = stdpopsim.drosophila_melanogaster
+species = getattr(stdpopsim,config["species"])
 
 # The specific model you would like to run
-model = species.SheehanSongThreeEpoch()
+model_class = getattr(species,config["model"])
+model = model_class()
 
 # The genetic map you would like to use.
-genetic_map = species.Comeron2012_dm6()
+genetic_map_class = getattr(species,config["genetic_map"])
+genetic_map = genetic_map_class()
 
 # A list containing the names all simulated chromosomes you would 
 # like to include in each analysis
 # TODO: Change this to list(species.genome.chromosomes)
-chrm_list = [chrom for chrom in species.genome.chromosomes][:2]
+chrm_list = [chrom for chrom in species.genome.chromosomes]
+if(config["chrm_list"] != "all"):
+    chrm_list = chrm_list[:config["chrm_list"]]
+
+# For plotting
+generation_time = config["generation_time"]
+
+# This grabs the default mr from the first chromosome,
+# Ultimitely This needs to be replaced with the weighted average
+# of all chromosomes: This should be done in stdpopsim. 
+mutation_rate = species.genome.mean_mutation_rate
 
 
 # ###############################################################################
@@ -84,8 +99,7 @@ stairwayplot_code = "stairwayplot/swarmops.jar"
 
 
 rule all:
-   input: output_dir + "/all_estimated_Ne.png"
-
+   input: output_dir + "/Results/all_estimated_Ne.pdf"
 
 rule download_genetic_map:
     output: genetic_map_downloaded_flag
@@ -105,14 +119,15 @@ rule simulation:
         genetic_map_downloaded_flag,
         # rules.top_directory.output,
     output:
-        output_dir + "/{seeds}/{chrms}.trees"
+        output_dir + "/Intermediate/{seeds}/{chrms}.trees"
     # TODO get simulation parameters from stdpopsim, so we can share them easily 
     # with anlysis code below?
     run: 
         simulations.simulate(
             out_path = output[0], species = species, model = model,
             genetic_map = genetic_map, seed = wildcards.seeds, 
-            chrmStr = wildcards.chrms, sample_size = num_sampled_genomes_per_replicate)
+            chrmStr = wildcards.chrms, sample_size = num_sampled_genomes_per_replicate,
+            population = population_id)
 
 
 # ###############################################################################
@@ -132,25 +147,25 @@ rule sp_download:
 
 rule run_stairwayplot:
     input:
-        expand(output_dir + "/{seeds}/{chrms}.trees",
+        expand(output_dir + "/Intermediate/{seeds}/{chrms}.trees",
             chrms=chrm_list, seeds=seed_array),
         stairwayplot_code,
-    output: output_dir + "/{seeds}/stairwayplot_estimated_Ne.txt"
+    output: output_dir + "/Results/{seeds}/stairwayplot_estimated_Ne.txt"
     threads: 20
     run: 
-        inputs = expand(output_dir + "/{seeds}/{chrms}.trees",
+        inputs = expand(output_dir + "/Intermediate/{seeds}/{chrms}.trees",
             seeds=wildcards.seeds, chrms=chrm_list)
         runner = stairway.StairwayPlotRunner(
             workdir= output_dir + "/stairwayplot/" + wildcards.seeds+"/",
             stairway_dir=pathlib.Path.cwd() / "stairwayplot")
-        runner.ts_to_stairway(inputs, num_bootstraps=12)
+        runner.ts_to_stairway(inputs, num_bootstraps=200)
         runner.run_theta_estimation(max_workers=threads, show_progress=True)
         # TODO get the rate here from stdpopsim. 
-        runner.run_summary(output, mutation_rate=1e-8, generation_time=10)
+        runner.run_summary(output, mutation_rate=mutation_rate, generation_time=generation_time)
 
 
 def ne_files(wildcards):
-    return expand(output_dir + "/{seeds}/stairwayplot_estimated_Ne.txt",
+    return expand(output_dir + "/Results/{seeds}/stairwayplot_estimated_Ne.txt",
             seeds=seed_array, chrms=chrm_list)
 
 
@@ -159,7 +174,7 @@ rule compound_stairwayplot:
         ne_files
     output:
         output_dir + "/stairwayplot_estimated_Ne.png"
-    run: plots.plot_compound_Ne_estimate(input, output[0])
+    run: plots.plot_compound_Ne_estimate(model, input, output[0])
 
 
 # ###############################################################################
@@ -169,26 +184,26 @@ rule compound_stairwayplot:
 
 rule ts_to_smc:
     input:rules.simulation.output
-    output: output_dir + "/{seeds}/{chrms}.trees.smc.gz"
+    output: output_dir + "/Intermediate/{seeds}/{chrms}.trees.smc.gz"
     run: smc.write_smcpp_file(input[0])
 
 
 rule run_smcpp:
     input:
-        expand(output_dir+ "/{seeds}/{chrms}.trees.smc.gz", 
+        expand(output_dir+ "/Intermediate/{seeds}/{chrms}.trees.smc.gz", 
             chrms=chrm_list, seeds=seed_array)
     output:
-        output_dir + "/{seeds}/trees.smc.gz.final.json"
+        output_dir + "/Intermediate/{seeds}/trees.smc.gz.final.json"
     threads: 8
     run:
 	    # need to cd into subdir because smc++ crashes otherwise
         cur = os.getcwd()
-        os.chdir(f"{output_dir}/{wildcards.seeds}")
+        os.chdir(f"{output_dir}/Intermediate/{wildcards.seeds}")
         inputs = expand("{chrms}.trees.smc.gz", chrms=chrm_list)
         inputs = " ".join(inputs)
         base = f"trees.smc.gz"
         # TODO get the rate here from stdpopsim
-        smc.run_smcpp_estimate(inputs, base, mutation_rate=1e-8, ncores=threads)
+        smc.run_smcpp_estimate(inputs, base, mutation_rate=mutation_rate, ncores=threads)
 	    # need to cd out of subdir for snakemake sanity
         os.chdir(cur)
 
@@ -197,21 +212,21 @@ rule smcpp_plot:
     input: 
         rules.run_smcpp.output
     output: 
-        output_dir + "/{seeds}/trees.smc.gz.final.json.csv"
+        output_dir + "/Results/{seeds}/trees.smc.gz.final.json.csv"
     run:
         # TODO get the genetion time from std source
-        smc.run_smcpp_plot(input[0], generation_time=10)
+        smc.run_smcpp_plot(input[0], output[0], generation_time=generation_time)
 
 
 def ne_files_smcpp(wildcards):
-    return expand(output_dir + "/{seeds}/trees.smc.gz.final.json.csv",
+    return expand(output_dir + "/Results/{seeds}/trees.smc.gz.final.json.csv",
             seeds=seed_array, chrms=chrm_list)
 
 
 rule compound_smcpp:
     input: ne_files_smcpp
-    output: output_dir + "/smcpp_estimated_Ne.png"
-    run: plots.plot_compound_smcpp(input, output[0])
+    output: output_dir + "/Results/smcpp_estimated_Ne.png"
+    run: plots.plot_compound_smcpp(model, input, output[0])
 
 
 # ###############################################################################
@@ -221,7 +236,7 @@ rule compound_smcpp:
 
 rule ts_to_multihep:
     input: rules.simulation.output
-    output: output_dir + "/{seeds}/{samps}.{chrms}.trees.multihep.txt"
+    output: output_dir + "/Intermediate/{seeds}/{samps}.{chrms}.trees.multihep.txt"
     run: msmc.write_msmc_file(input[0], num_sampled_genomes_msmc)
 
 
@@ -229,34 +244,34 @@ rule run_msmc:
     input:
         # TODO make this NOT dependent on all simulations.
         # is there anyway to get access to wildcards.seeds from here? 
-        expand(output_dir + "/{seeds}/{samps}.{chrms}.trees.multihep.txt",
+        expand(output_dir + "/Intermediate/{seeds}/{samps}.{chrms}.trees.multihep.txt",
             chrms=chrm_list, seeds=seed_array, samps=num_sampled_genomes_msmc)
-    output: output_dir + "/{seeds}/{samps}.trees.multihep.txt.final.txt"
+    output: output_dir + "/Intermediate/{seeds}/{samps}.trees.multihep.txt.final.txt"
     threads: 40
     run: 
-        inputs = expand(output_dir + "/{seeds}/{samps}.{chrms}.trees.multihep.txt",
+        inputs = expand(output_dir + "/Intermediate/{seeds}/{samps}.{chrms}.trees.multihep.txt",
             seeds=wildcards.seeds, samps=wildcards.samps, chrms=chrm_list)
         input_file_string = " ".join(inputs)
-        output_file_string = output_dir + f"/{wildcards.seeds}/{wildcards.samps}.trees.multihep.txt"
+        output_file_string = output_dir + f"/Intermediate/{wildcards.seeds}/{wildcards.samps}.trees.multihep.txt"
         msmc.run_msmc_estimate(input_file_string, output_file_string, msmc_exec,
             iterations=num_msmc_iterations, ncores=threads)
 
 
 rule convert_msmc:
     input: rules.run_msmc.output
-    output: output_dir + "/{seeds}/{samps}.trees.multihep.txt.final.txt.csv"
-    run: msmc.convert_msmc_output(input[0], mutation_rate=1e-8, generation_time = 10)
+    output: output_dir + "/Results/{seeds}/{samps}.trees.multihep.txt.final.txt.csv"
+    run: msmc.convert_msmc_output(input[0] ,output[0], mutation_rate=mutation_rate, generation_time=generation_time)
 
 
 def ne_files_msmc(wildcards):
-    return expand(output_dir + "/{seeds}/{samps}.trees.multihep.txt.final.txt.csv",
+    return expand(output_dir + "/Results/{seeds}/{samps}.trees.multihep.txt.final.txt.csv",
             seeds=seed_array,samps=num_sampled_genomes_msmc)
 
 
 rule compound_msmc:
     input: ne_files_msmc,
-    output: output_dir+"/msmc_estimated_Ne.png"
-    run: plots.plot_compound_msmc(input, output[0])
+    output: output_dir+"/Results/msmc_estimated_Ne.png"
+    run: plots.plot_compound_msmc(model, input, output[0])
 
 
 # ###############################################################################
@@ -270,15 +285,18 @@ rule all_plot:
         f2 = ne_files_smcpp,
         f3 = ne_files_msmc,
     output:
-        output_dir + "/all_estimated_Ne.png"
+        output_dir + "/Results/all_estimated_Ne.pdf"
     run: 
-        plots.plot_all_ne_estimates(input.f1, input.f2, input.f3, output[0])
+        plots.plot_all_ne_estimates(input.f1, input.f2, input.f3, output[0],
+                    model=model, n_samp=num_sampled_genomes_per_replicate,
+                    generation_time=generation_time, species=config["species"],
+                    pop_id=population_id)
 
 
 rule clean:
     shell:
-        "rm -rf stairwayplot \
+        f"rm -rf stairwayplot \
             stairwayplot.tar.gz \
-            "+output_dir+" \
+            {output_dir}/Intermediate \
             .genetic_map_downloaded \
             .snakemake"

--- a/n_t/cluster_talapas.json
+++ b/n_t/cluster_talapas.json
@@ -1,14 +1,10 @@
 {
     "__default__" :
     {
-        "time" : "00:10:00",
+        "time" : "10:00:00",
         "n" : 1,
-        "partition" : "kern,preempt"
+        "partition" : "kern",
+        "mem" : "32G",
+        "cores" : "4",
     },
-    "homo_sapiens_Gutenkunst_stairwayplot" :
-    {
-        "time" : "00:10:00",
-	"n" : 8,
-	"partition" : "kern,preempt"
-    }
 }

--- a/n_t/msmc.py
+++ b/n_t/msmc.py
@@ -60,12 +60,12 @@ def run_msmc_estimate(input_files, output_file, msmc_exec_loc, iterations=1, nco
     """
     
     cmd = (f"{msmc_exec_loc} --fixedRecombination -o \
-        {output_file} -i {iterations} -t {ncores} {input_files}")
+        {output_file} -i {iterations} {input_files}")
     subprocess.run(cmd, shell=True, check=True)
     return None
 
 
-def convert_msmc_output(results_file, mutation_rate, generation_time):
+def convert_msmc_output(results_file, outfile, mutation_rate, generation_time):
     """
     This function converts the output from msmc into a csv the will be read in for
     plotting comparison.
@@ -79,7 +79,6 @@ def convert_msmc_output(results_file, mutation_rate, generation_time):
     To get population sizes out of coalescence rates, first take the inverse of the coalescence rate, 
     scaledPopSize = 1 / lambda00. Then divide this scaled population size by 2*mu
     """
-    outfile = results_file+".csv"
     out_fp = open(outfile, "w")
     in_fp = open(results_file, "r")
     header = in_fp.readline()

--- a/n_t/plots.py
+++ b/n_t/plots.py
@@ -4,7 +4,11 @@ Code for generating plots.
 import pandas
 import seaborn as sns
 import matplotlib
+import msprime
+import os
+import matplotlib.patches as mpatches
 from matplotlib import pyplot as plt
+import numpy as np
 # Force matplotlib to not use any Xwindows backend.
 matplotlib.use('Agg')
 
@@ -56,25 +60,46 @@ def plot_compound_msmc(infiles, outfile):
     f.savefig(outfile, bbox_inches='tight')
 
 
-def plot_all_ne_estimates(sp_infiles, smcpp_infiles, msmc_infiles, outfile):
-    f, ax = plt.subplots(figsize=(7, 7))
-    ax.set(xscale="log", yscale="log")
-    # plot smcpp estimates
+def plot_all_ne_estimates(sp_infiles, smcpp_infiles, msmc_infiles, outfile,
+                            model, n_samp, generation_time, species,
+                            pop_id = 0, steps=None):
+
+    ddb = msprime.DemographyDebugger(**model.asdict())
+    if steps is None:
+        end_time = ddb.epochs[-2].end_time + 10000
+        steps = np.linspace(1,end_time,end_time+1)
+    num_samples = [0 for _ in range(ddb.num_populations)]
+    num_samples[pop_id] = n_samp
+    coal_rate, P = ddb.coalescence_rate_trajectory(steps=steps,
+        num_samples=num_samples, double_step_validation=False)
+    steps = steps * generation_time
+    num_msmc = set([os.path.basename(infile).split(".")[0] for infile in msmc_infiles])
+    num_msmc = sorted([int(x) for x in num_msmc])
+    f, ax = plt.subplots(1,2+len(num_msmc),sharex=True,sharey=True,figsize=(14, 7))
     for infile in smcpp_infiles:
         nt = pandas.read_csv(infile, usecols=[1, 2], skiprows=0)
-        line1, = ax.plot(nt['x'], nt['y'], c="red", alpha=0.8, label='smc++')
-    # plot stairwayplot estimates
+        line1, = ax[0].plot(nt['x'], nt['y'], alpha=0.8)
+    ax[0].plot(steps, 1/(2*coal_rate), c="black")
+    ax[0].set_title("smc++")
     for infile in sp_infiles:
         nt = pandas.read_csv(infile, sep="\t", skiprows=5)
-        line2, = ax.plot(nt['year'], nt['Ne_median'], c="blue", label='stairwayplot')
-    # plot msmc estimates
-    for infile in msmc_infiles:
-        samp = infile.split(".")[1]
-        nt = pandas.read_csv(infile, usecols=[1, 2], skiprows=0)
-        line3, = ax.plot(nt['x'], nt['y'], c="purple", alpha=0.8, label='msmc '+samp+" samples")
-    # TODO add a plot  of true history
-
-    ax.set_xlabel("time (years)")
-    ax.set_ylabel("population size")
-    ax.legend((line1, line2, line3), ('smc++', 'stairwayplot', 'msmc'))
+        line2, = ax[1].plot(nt['year'], nt['Ne_median'],alpha=0.8)
+    ax[1].plot(steps, 1/(2*coal_rate), c="black")
+    ax[1].set_title("stairwayplot")
+    for i,sample_size in enumerate(num_msmc):
+        for infile in msmc_infiles:
+            fn = os.path.basename(infile)
+            samp = fn.split(".")[0]
+            if(int(samp) == sample_size):
+                nt = pandas.read_csv(infile, usecols=[1, 2], skiprows=0)
+                line3, = ax[2+i].plot(nt['x'], nt['y'],alpha=0.8)
+        ax[2+i].plot(steps, 1/(2*coal_rate), c="black")
+        ax[2+i].set_title(f"msmc, ({sample_size} samples)")
+    plt.suptitle(f"{species}, population id {pop_id}", fontsize = 16)
+    for i in range(2+len(num_msmc)):
+        ax[i].set(xscale="log", yscale="log")
+        ax[i].set_xlabel("time (years ago)")
+    red_patch = mpatches.Patch(color='black', label='Coalescence rate derived Ne')
+    ax[0].legend(frameon=False, fontsize=10, handles=[red_patch])
+    ax[0].set_ylabel("population size")
     f.savefig(outfile, bbox_inches='tight', alpha=0.8)

--- a/n_t/simulations.py
+++ b/n_t/simulations.py
@@ -6,10 +6,11 @@ import msprime
 from stdpopsim import homo_sapiens
 
 
-def simulate(out_path, species, model, genetic_map, seed, chrmStr, sample_size=20):
+def simulate(out_path, species, model, genetic_map, seed, chrmStr, 
+             sample_size=20, population=0):
     chrom = species.genome.chromosomes[chrmStr]
     # TODO : Sample outside of population 0?
-    samples = [msprime.Sample(population=0, time=0)] * sample_size
+    samples = [msprime.Sample(population=population, time=0)] * sample_size
     ts = msprime.simulate(
         samples=samples,
         recombination_map=chrom.recombination_map(genetic_map.name),

--- a/n_t/smc.py
+++ b/n_t/smc.py
@@ -51,7 +51,7 @@ def run_smcpp_estimate(input_file, base, mutation_rate, ncores):
     logging.info("Running:" + cmd)
     subprocess.run(cmd, shell=True, check=True)
 
-def run_smcpp_plot(input_file, generation_time):
+def run_smcpp_plot(input_file, output_file, generation_time):
     """
     Runs smc++ plot on the specified file, resulting in the output being written
     to the file input_file.png".
@@ -59,4 +59,6 @@ def run_smcpp_plot(input_file, generation_time):
     cmd = (
         f"smc++ plot {input_file}.png {input_file} -g {generation_time} -c")
     logging.info("Running:" + cmd)
+    subprocess.run(cmd, shell=True, check=True)
+    cmd = (f"cp {input_file}.csv  {output_file}")
     subprocess.run(cmd, shell=True, check=True)


### PR DESCRIPTION
This pull request changes several things about the `n_t` analysis workflow. 
1. Each analysis run requires a config file.
2. Plotting has been bulked up and includes the ground truth now.
3. the intermediate and Results files have been separated such that you can pass around the predictions (presumably for data analysis and plotting) without the bulky intermediate files generated as a by-product of the analysis.
4. Updated documentation. 
5. a Few parameters in the Snakefile pertaining to the individual software parameters passed - most notably generation time and bootstrap iterations.

NOTE: To run an analysis with the code in this PR, you must have the bleeding edge `msprime` installed (For ground truth coalescent rates).