### PR TITLE
changed chromosome list to allow for simulation of any focal chromoso…

### DIFF
--- a/n_t/Snakefile
+++ b/n_t/Snakefile
@@ -71,12 +71,11 @@ model = model_class()
 genetic_map_class = getattr(species,config["genetic_map"])
 genetic_map = genetic_map_class()
 
-# A list containing the names all simulated chromosomes you would 
-# like to include in each analysis
-# TODO: Change this to list(species.genome.chromosomes)
+# The names of all chromosomes to simulate, separated by commas
+# Use "all" to simulate all chromsomes for the genome
 chrm_list = [chrom for chrom in species.genome.chromosomes]
 if(config["chrm_list"] != "all"):
-    chrm_list = chrm_list[:config["chrm_list"]]
+    chrm_list = [chr for chr in config["chrm_list"].split(",")]
 
 # For plotting
 generation_time = config["generation_time"]
@@ -152,7 +151,7 @@ rule run_stairwayplot:
         stairwayplot_code,
     output: output_dir + "/Results/{seeds}/stairwayplot_estimated_Ne.txt"
     threads: 20
-    run: 
+    run:
         inputs = expand(output_dir + "/Intermediate/{seeds}/{chrms}.trees",
             seeds=wildcards.seeds, chrms=chrm_list)
         runner = stairway.StairwayPlotRunner(
@@ -286,7 +285,7 @@ rule all_plot:
         f3 = ne_files_msmc,
     output:
         output_dir + "/Results/all_estimated_Ne.pdf"
-    run: 
+    run:
         plots.plot_all_ne_estimates(input.f1, input.f2, input.f3, output[0],
                     model=model, n_samp=num_sampled_genomes_per_replicate,
                     generation_time=generation_time, species=config["species"],

--- a/n_t/readme.md
+++ b/n_t/readme.md
@@ -46,7 +46,7 @@ might look like this:
     "species" : "homo_sapiens",
     "model" : "GutenkunstThreePopOutOfAfrica",
     "genetic_map" : "HapmapII_GRCh37",
-    "chrm_list" : "all",
+    "chrm_list" : "chr22,chrX",
     "generation_time" : 25,
 }
 ```
@@ -143,7 +143,8 @@ should inherit from `<class Model>`
 `genetic_map` : `<class childclass GeneticMap>` This will define the genetic map
 used for simulations.
 
-`chrm_list` : `<class 'list[str]'>` The chromosomes you would like to simulate
-for input into each of the analysis run. All chromosomes simulated will be fed
+`chrm_list` : `<class 'str'>` A string of the chromosome names you would like to simulate,
+separated by commas. All chromosomes simulated will be fed
 as a single input into each analysis by the inference programs, for each replicate.
+Set to "all" to simulate all chromsomes for the genome.
 

--- a/n_t/simulations.py
+++ b/n_t/simulations.py
@@ -6,7 +6,7 @@ import msprime
 from stdpopsim import homo_sapiens
 
 
-def simulate(out_path, species, model, genetic_map, seed, chrmStr, 
+def simulate(out_path, species, model, genetic_map, seed, chrmStr,
              sample_size=20, population=0):
     chrom = species.genome.chromosomes[chrmStr]
     # TODO : Sample outside of population 0?


### PR DESCRIPTION
I noticed previously, that setting "chrm_list" to any specific chromosome number in the config.json would simulate chromosomes 1 through that number (e.g. "chrm_list" : 22 would simulate chromosomes 1-22). I changed the Snakefile and the readme so that now you can just use a string, where all chromosomes you want to simulate are separated by a comma (e.g. now "chrm_list" : "chr1,chr2,chrX" simulates only chromosomes 1, 2, and X). I did not alter the functionality of using "all" to simulate all chromosomes for the genome.